### PR TITLE
Improve testing (close #8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +28,26 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2f2e73fffe9455141e170fb9c1feb0ac521ec7e7dcd47a7cab72a658490fb8"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_with",
+]
 
 [[package]]
 name = "bumpalo"
@@ -45,6 +74,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,13 +106,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -86,11 +174,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.1",
  "quote",
  "syn",
 ]
@@ -110,7 +209,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
 dependencies = [
- "darling",
+ "darling 0.14.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -124,6 +223,17 @@ checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -176,42 +286,102 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.21"
+name = "futures"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
-name = "futures-sink"
-version = "0.3.21"
+name = "futures-executor"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
-
-[[package]]
-name = "futures-task"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
-
-[[package]]
-name = "futures-util"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+
+[[package]]
+name = "futures-task"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+
+[[package]]
+name = "futures-util"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -222,7 +392,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -257,6 +427,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -328,6 +513,19 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
 ]
 
 [[package]]
@@ -434,7 +632,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -454,6 +652,25 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -542,6 +759,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +780,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -697,6 +950,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +999,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "testcontainers",
  "tokio",
  "uuid",
 ]
@@ -732,6 +1019,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -755,6 +1048,34 @@ dependencies = [
  "libc",
  "redox_syscall",
  "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e2b1567ca8a2b819ea7b28c92be35d9f76fb9edb214321dcc86eb96023d1f87"
+dependencies = [
+ "bollard-stubs",
+ "futures",
+ "hex",
+ "hmac",
+ "log",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -860,6 +1181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +1250,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ serde = { version = "1.0.140", features = ["derive"] }
 serde_json = "1.0.82"
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 derive_builder = "0.11.2"
+
+[dev-dependencies]
+testcontainers = "0.14.0"

--- a/src/event.rs
+++ b/src/event.rs
@@ -196,12 +196,15 @@ mod tests {
     fn builds_payload_for_self_describing_event() {
         let event = SelfDescribingEvent {
             schema: "schema.com".to_string(),
-            data: json!({"targetUrl": "http://a-target-url.com"})
+            data: json!({}),
         };
         let payload_builder = payload_builder();
         let payload = event.build_payload(payload_builder);
         let ue_pr = payload.ue_pr.unwrap();
-        assert_eq!(ue_pr.schema, "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0");
+        assert_eq!(
+            ue_pr.schema,
+            "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0"
+        );
         assert_eq!(ue_pr.data.schema, "schema.com");
     }
 
@@ -217,6 +220,7 @@ mod tests {
             .unwrap();
         let payload_builder = payload_builder();
         let payload = event.build_payload(payload_builder);
+
         assert_eq!(payload.se_ca.unwrap(), "shop");
         assert_eq!(payload.se_ac.unwrap(), "add-to-basket");
         assert_eq!(payload.se_la.unwrap(), "Add To Basket");
@@ -234,13 +238,16 @@ mod tests {
         let payload_builder = payload_builder();
         let payload = event.build_payload(payload_builder);
         let ue_pr = payload.ue_pr.unwrap();
-        assert_eq!(ue_pr.data.schema, "iglu:com.snowplowanalytics.mobile/screen_view/jsonschema/1-0-0");
+        assert_eq!(
+            ue_pr.data.schema,
+            "iglu:com.snowplowanalytics.mobile/screen_view/jsonschema/1-0-0"
+        );
     }
 
     fn payload_builder() -> PayloadBuilder {
         Payload::builder()
             .p("platform".to_string())
-            .tv("0.1.9".to_string())
+            .tv("0.1.0".to_string())
             .eid(Uuid::new_v4())
             .dtm("1".to_string())
             .stm("1".to_string())

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -75,3 +75,24 @@ impl Tracker {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+        #[test]
+        fn create_new_tracker() {
+            let tracker = Tracker::new(
+                "test namespace",
+                "test app id",
+                Emitter::new("http://example.com/")
+            );
+
+            assert_eq!(tracker.namespace, "test namespace");
+            assert_eq!(tracker.app_id, "test app id");
+            assert_eq!(tracker.emitter.collector_url, "http://example.com/");
+            assert_eq!(tracker.config.platform, "pc".to_string());
+            assert_eq!(tracker.config.version, "rust-0.1.0".to_string());
+            assert_eq!(tracker.config.encode_base_64, false);
+        }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,167 @@
+use serde_json::json;
+use testcontainers::core::WaitFor;
+use testcontainers::images::generic::GenericImage;
+use testcontainers::{clients::Cli, Container};
+use uuid::Uuid;
+
+use snowplow_tracker::{
+    ScreenViewEvent, SelfDescribingEvent, SelfDescribingJson, Snowplow, StructuredEvent,
+};
+
+fn get_micro() -> GenericImage {
+    let running_message = WaitFor::message_on_stderr("REST interface bound to /0.0.0.0:9090");
+
+    GenericImage::new("snowplow/snowplow-micro", "latest")
+        .with_exposed_port(9090)
+        .with_wait_for(running_message.clone())
+}
+
+async fn get_micro_endpoint(micro_url: &str, page: &str) -> serde_json::Value {
+    let resp = reqwest::get(micro_url.to_string() + "/micro/" + page)
+        .await
+        .unwrap();
+    let text = resp.text().await.unwrap();
+    serde_json::from_str(&text).unwrap()
+}
+
+fn setup(docker: &'_ Cli) -> (Container<'_, GenericImage>, String) {
+    let container = docker.run(get_micro());
+    let host_port = container.get_host_port_ipv4(9090);
+    let micro_url = format!("http://0.0.0.0:{host_port}");
+    (container, micro_url)
+}
+
+#[tokio::test]
+async fn track_valid_event_to_good() {
+    let docker = Cli::default();
+    let (_container, micro_url) = setup(&docker);
+
+    let tracker = Snowplow::create_tracker("ns", "app_id", &micro_url);
+
+    let screenview_event = ScreenViewEvent::builder()
+        .id(Uuid::new_v4())
+        .name("a screen view")
+        .previous_name("previous screen".to_string())
+        .build()
+        .unwrap();
+
+    tracker.track(screenview_event, None).await;
+
+    let all_events = get_micro_endpoint(&micro_url, "all").await;
+    assert_eq!(1, all_events["good"]);
+}
+
+#[tokio::test]
+async fn track_screen_view_event() {
+    let docker = Cli::default();
+    let (_container, micro_url) = setup(&docker);
+
+    let tracker = Snowplow::create_tracker("ns", "app_id", &micro_url);
+
+    let screenview_event = ScreenViewEvent::builder()
+        .id(Uuid::new_v4())
+        .name("a screen view")
+        .previous_name("previous screen".to_string())
+        .build()
+        .unwrap();
+
+    let expected_event = json!({
+        "schema": "iglu:com.snowplowanalytics.mobile/screen_view/jsonschema/1-0-0".to_string(),
+        "data" : serde_json::to_value(&screenview_event).unwrap(),
+    });
+
+    tracker.track(screenview_event, None).await.unwrap();
+
+    let good_events = get_micro_endpoint(&micro_url, "good").await;
+
+    assert_eq!(
+        expected_event,
+        good_events.as_array().unwrap().last().unwrap()["event"]["unstruct_event"]["data"]
+    );
+}
+
+#[tokio::test]
+async fn track_structured_event() {
+    let docker = Cli::default();
+    let (_container, micro_url) = setup(&docker);
+
+    let tracker = Snowplow::create_tracker("ns", "app_id", &micro_url);
+
+    let structured_event = StructuredEvent::builder()
+        .category("shop")
+        .action("add-to-basket")
+        .label("Add To Basket".to_string())
+        .property("pcs".to_string())
+        .value(2.0)
+        .build()
+        .unwrap();
+
+    let expected_event = serde_json::to_value(&structured_event).unwrap();
+
+    tracker.track(structured_event, None).await.unwrap();
+
+    let good_events = get_micro_endpoint(&micro_url, "good").await;
+
+    let properties = vec!["category", "action", "label", "property", "value"];
+    for prop in properties {
+        assert_eq!(
+            expected_event[prop],
+            good_events.as_array().unwrap().last().unwrap()["event"][format!("se_{prop}")]
+        );
+    }
+}
+
+#[tokio::test]
+async fn track_self_describing_event() {
+    let docker = Cli::default();
+    let (_container, micro_url) = setup(&docker);
+
+    let tracker = Snowplow::create_tracker("ns", "app_id", &micro_url);
+    tracker
+        .track(
+            SelfDescribingEvent {
+                schema: "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0"
+                    .to_string(),
+                data: json!({"name": "test", "id": "something else"}),
+            },
+            Some(vec![SelfDescribingJson::new(
+                "iglu:org.schema/WebPage/jsonschema/1-0-0",
+                json!({"keywords": ["tester"]}),
+            )]),
+        )
+        .await;
+
+    let good_events = get_micro_endpoint(&micro_url, "good").await;
+    let received_event = good_events.as_array().unwrap().last().unwrap();
+
+    let expected_unstruct_event = json!({
+        "data": {
+          "id": "something else",
+          "name": "test"
+        },
+        "schema": "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0"
+    });
+
+    assert_eq!(
+        received_event["event"]["unstruct_event"]["data"],
+        expected_unstruct_event
+    );
+
+    let expected_context = json!({
+        "data": {
+            "keywords": [
+                "tester"
+            ]
+        },
+        "schema": "iglu:org.schema/WebPage/jsonschema/1-0-0",
+    });
+
+    assert_eq!(
+        received_event["event"]["contexts"]["data"]
+            .as_array()
+            .unwrap()
+            .first()
+            .unwrap(),
+        &expected_context
+    );
+}


### PR DESCRIPTION
This PR has some general improvements/tidy up to testing.

Integration tests have been added using Micro through the usage of the `testcontainers` crate. Using the docker image instead of specifying a `.jar` to fetch allows us to use the `latest` tag, preventing the Micro version used in testing fall behind.  

The `fake` crate has also been added to create types for testing in situations where the value/format of those types is irrelevant, and values have been replaced by fakes where appropriate. 

A specific change [here](https://github.com/snowplow-incubator/snowplow-rust-tracker/compare/release/0.1.0...issue/8-improve_testing?expand=1#diff-14da7c350de5742eaa248de110fefeae9b4b639c0358e26024d6040ccf174a41R205) was also done as the content of the json wasn't used in the test 
