### PR TITLE
Add TimingEvent (close #11)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub use emitter::Emitter;
 pub use event::ScreenViewEvent;
 pub use event::SelfDescribingEvent;
 pub use event::StructuredEvent;
+pub use event::TimingEvent;
 pub use payload::SelfDescribingJson;
 pub use snowplow::Snowplow;
 pub use tracker::Tracker;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,8 @@ async fn main() {
             StructuredEvent::builder()
                 .category("shop")
                 .action("add-to-basket")
-                .label("Add To Basket".to_string())
-                .property("pcs".to_string())
+                .label("Add To Basket")
+                .property("pcs")
                 .value(2.0)
                 .build()
                 .unwrap(),
@@ -54,7 +54,7 @@ async fn main() {
             ScreenViewEvent::builder()
                 .id(Uuid::new_v4())
                 .name("a screen view")
-                .previous_name("previous screen".to_string())
+                .previous_name("previous name")
                 .build()
                 .unwrap(),
             None,


### PR DESCRIPTION
`TimingEvent` has been added, along with unit and integration tests, and a bit of a tidy where possible for builders.

## Builder Tidying:
- Attributes that were previously declared many times on fields such as `#[setter(into)]` can be applied struct-level.
- `ScreenViewEvent` previously manually renamed attributes to camelCase. We can apply the `#[serde(rename_all = "camelCase")]` attribute to the struct, and keep the override on the `screen_type` field with `#[serde(rename(serialize = "type"))]` so it keeps the correct name. The `track_screen_view_event` integration test has been updated to use all fields in the struct.

Whilst doing this, I stumbled across a nice little API improvement with the `strip_option` attribute, which means users don't have to call `to_string` on optional builder fields, e.g.:
```rust
let screenview_event = ScreenViewEvent::builder()
    .id(Uuid::new_v4())
    .name("a screen view")
    .previous_name("previous name".to_string())
```
becomes
```rust
let screenview_event = ScreenViewEvent::builder()
    .id(Uuid::new_v4())
    .name("a screen view")
    .previous_name("previous name")
```

Code examples and tests have been updated appropriately for this change.