### PR TITLE
Create `Subject` (close #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,17 @@ use snowplow_tracker::Snowplow;
 ### Using the Tracker
 
 Instantiate a tracker using the `Snowplow::create_tracker` function.
-The function takes three required arguments: `namespace` and `app_id`, and `collector_url`.
-Tracker namespace identifies the tracker instance; you may create multiple trackers with different namespaces.
+The function takes three required arguments: `namespace`, `app_id`, `collector_url`, and one optional argument, `subject`.
+Tracker `namespace` identifies the tracker instance; you may create multiple trackers with different namespaces.
 The `app_id` identifies your app.
 The `collector_url` is the URI of the Snowplow collector to send the events to.
+`subject` allows for an optional Subject to be attached to the tracker, which will be sent with all events
 
 ```rust
-let tracker = Snowplow::create_tracker("ns", "app_id", "https://...");
+use snowplow_tracker::Subject;
+let subject = Subject::builder().language("en-gb").build().unwrap();
+
+let tracker = Snowplow::create_tracker("ns", "app_id", "https://...", Some(subject));
 ```
 
 To track events, simply instantiate their respective types and pass them to the `tracker.track` method with optional context entities.
@@ -61,10 +65,11 @@ tracker.track(
 
 // Tracking a self-describing event with a context entity
 tracker.track(
-    SelfDescribingEvent {
-        schema: "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1".to_string(),
-        data: json!({"targetUrl": "http://a-target-url.com"})
-    },
+    SelfDescribingEvent.builder()
+        .schema("iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1"),
+        .data(json!({"targetUrl": "http://a-target-url.com"}))
+		.build()
+		.unwrap(),
     Some(vec![
         SelfDescribingJson::new("iglu:org.schema/WebPage/jsonschema/1-0-0", json!({"keywords": ["tester"]}))
     ])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,21 +16,31 @@
 //! ## Example usage
 //!
 //! ```
-//! use snowplow_tracker::{Snowplow, SelfDescribingJson, SelfDescribingEvent};
+//! use snowplow_tracker::{Snowplow, SelfDescribingJson, SelfDescribingEvent, Subject};
 //! use serde_json::json;
 //!
-//! // Initialize a tracker instance given a namespace, application ID, and Snowplow collector URL
-//! let tracker = Snowplow::create_tracker("ns", "app_id", "https://...");
+//! // Initialize a tracker instance given a namespace, application ID, Snowplow collector URL, and
+//! // Subject
+//!
+//! let subject = Subject::builder().language("en-gb").build().unwrap();
+//! let tracker = Snowplow::create_tracker("ns", "app_id", "https://...", Some(subject));
 //!
 //! // Tracking a self-describing event with a context entity
 //! tracker.track(
-//!     SelfDescribingEvent {
-//!         schema: "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1".to_string(),
-//!         data: json!({"targetUrl": "http://a-target-url.com"})
-//!     },
+//!     SelfDescribingEvent::builder()
+//!         .schema("iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1")
+//!         .data(json!({"targetUrl": "http://a-target-url.com"}))
+//!         .subject(
+//!             Subject::builder()
+//!             .user_id("user_1")
+//!             .build()
+//!             .unwrap()
+//!         )
+//!         .build()
+//!         .unwrap(),
 //!     Some(vec![
 //!         SelfDescribingJson::new("iglu:org.schema/WebPage/jsonschema/1-0-0", json!({"keywords": ["tester"]}))
-//!     ])
+//!     ]),
 //! );
 //! ```
 
@@ -38,6 +48,7 @@ mod emitter;
 mod event;
 mod payload;
 mod snowplow;
+mod subject;
 mod tracker;
 
 pub use emitter::Emitter;
@@ -47,4 +58,5 @@ pub use event::StructuredEvent;
 pub use event::TimingEvent;
 pub use payload::SelfDescribingJson;
 pub use snowplow::Snowplow;
+pub use subject::Subject;
 pub use tracker::Tracker;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,15 +17,15 @@ use uuid::Uuid;
 
 #[tokio::main]
 async fn main() {
-    let tracker = Snowplow::create_tracker("ns", "app_id", "http://localhost:9090");
+    let tracker = Snowplow::create_tracker("ns", "app_id", "http://localhost:9090", None);
 
     let self_desc_event_id = tracker
         .track(
-            SelfDescribingEvent {
-                schema: "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0"
-                    .to_string(),
-                data: json!({"name": "test", "id": "something else"}),
-            },
+            SelfDescribingEvent::builder()
+                .schema("iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0")
+                .data(json!({"name": "test", "id": "something else"}))
+                .build()
+                .unwrap(),
             Some(vec![SelfDescribingJson::new(
                 "iglu:org.schema/WebPage/jsonschema/1-0-0",
                 json!({"keywords": ["tester"]}),

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -14,6 +14,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::Value;
 
+use crate::StructuredEvent;
+use crate::Subject;
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum EventType {
     #[serde(rename(serialize = "se"))]
@@ -25,41 +28,37 @@ pub enum EventType {
 #[derive(Builder, Serialize, Deserialize, Default, Clone, Debug)]
 #[builder(field(public))]
 #[builder(pattern = "owned")]
+#[builder(setter(strip_option))]
 pub struct Payload {
     p: String,
     tv: String,
     pub eid: uuid::Uuid,
     dtm: String,
     stm: String,
-    #[builder(setter(strip_option))]
+
+    #[builder(default)]
     e: Option<EventType>,
     aid: String,
+
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option))]
     pub(crate) ue_pr: Option<SelfDescribingEventData>,
+
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option))]
     co: Option<ContextData>,
-    // Stuctured Event
+
+    // Structured Event
     #[builder(default)]
+    #[serde(flatten)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option))]
-    pub(crate) se_ca: Option<String>,
+    pub(crate) structured_event: Option<StructuredEvent>,
+
+    // Subject
     #[builder(default)]
+    #[serde(flatten)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option))]
-    pub(crate) se_ac: Option<String>,
-    #[builder(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) se_la: Option<String>,
-    #[builder(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) se_pr: Option<String>,
-    #[builder(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) se_va: Option<String>,
+    pub(crate) subject: Option<Subject>,
 }
 
 impl Payload {

--- a/src/snowplow.rs
+++ b/src/snowplow.rs
@@ -10,6 +10,7 @@
 // See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 
 use crate::emitter::Emitter;
+use crate::subject::Subject;
 use crate::tracker::Tracker;
 
 pub struct Snowplow;
@@ -17,9 +18,13 @@ pub struct Snowplow;
 /// Main interface for the package used to initialize trackers.
 impl Snowplow {
     /// Creates a new Tracker instance that can be used to track events
-    pub fn create_tracker(namespace: &str, app_id: &str, collector_url: &str) -> Tracker {
+    pub fn create_tracker(
+        namespace: &str,
+        app_id: &str,
+        collector_url: &str,
+        subject: Option<Subject>,
+    ) -> Tracker {
         let emitter = Emitter::new(collector_url);
-        let tracker = Tracker::new(namespace, app_id, emitter);
-        tracker
+        Tracker::new(namespace, app_id, emitter, subject)
     }
 }

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -1,0 +1,164 @@
+// Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Subject allows you to attach additional information about your application's environment
+///
+/// A Subject can be (attached to either a Tracker) where it will be sent with every Event, and/or
+/// attached to an Event, with the Event-level subject taking priority over Tracker-level
+#[derive(Serialize, Deserialize, Builder, Default, Clone, Debug)]
+#[builder(setter(into, strip_option), default)]
+pub struct Subject {
+    /// Unique identifier for user
+    #[serde(rename(serialize = "uid"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+
+    /// The timezone label.
+    ///
+    /// Populates the `os_timezone` field.
+    #[serde(rename(serialize = "tz"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+
+    /// The language set on the device.
+    ///
+    /// Populates the `lang` field.
+    #[serde(rename(serialize = "lang"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+
+    /// Custom IP address. It overrides the IP address used by default.
+    ///
+    /// Populates the `user_ipaddress` field.
+    #[serde(rename(serialize = "ip"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip_address: Option<String>,
+
+    /// Custom user-agent. It overrides the user-agent used by default.
+    ///
+    /// Populates the `useragent` field.
+    #[serde(rename(serialize = "ua"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
+
+    /// Domain user ID (UUIDv4).
+    ///
+    /// Populates the `domain_userid` field.
+    /// Typically used to link native tracking to in-app browser events tracked using the JavaScript Tracker.
+    #[serde(rename(serialize = "duid"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain_user_id: Option<Uuid>,
+
+    /// Network user ID (UUIDv4).
+    ///
+    /// Populates the `network_userid` field.
+    /// Typically used to link native tracking to in-app browser events tracked using the JavaScript Tracker.
+    /// Normally one would retrieve the network userid from the browser and pass it to the app.
+    #[serde(rename(serialize = "tnuid"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network_user_id: Option<Uuid>,
+
+    /// Session user ID (UUIDv4)
+    ///
+    /// Unique identifier (UUID) for this visit of this user_id to this domain
+    #[serde(rename(serialize = "sid"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_user_id: Option<Uuid>,
+}
+
+impl Subject {
+    pub fn builder() -> SubjectBuilder {
+        SubjectBuilder::default()
+    }
+
+    /// Merges another instance of [Subject], with self taking priority
+    pub fn merge(self, other: Subject) -> Self {
+        Self {
+            user_id: self.user_id.or(other.user_id),
+            timezone: self.timezone.or(other.timezone),
+            language: self.language.or(other.language),
+            ip_address: self.ip_address.or(other.ip_address),
+            user_agent: self.user_agent.or(other.user_agent),
+            domain_user_id: self.domain_user_id.or(other.domain_user_id),
+            network_user_id: self.network_user_id.or(other.network_user_id),
+            session_user_id: self.session_user_id.or(other.session_user_id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_build_subject_all_fields() {
+        let domain_user_id = Uuid::new_v4();
+        let network_user_id = Uuid::new_v4();
+        let session_user_id = Uuid::new_v4();
+        let subject = Subject::builder()
+            .user_id("user_1")
+            .timezone("Europe/London")
+            .language("en")
+            .ip_address("0.0.0.0")
+            .user_agent("Mozilla/Firefox")
+            .domain_user_id(domain_user_id)
+            .network_user_id(network_user_id)
+            .session_user_id(session_user_id)
+            .build()
+            .unwrap();
+
+        assert_eq!("user_1".to_string(), subject.user_id.unwrap());
+        assert_eq!("Europe/London".to_string(), subject.timezone.unwrap());
+        assert_eq!("en".to_string(), subject.language.unwrap());
+        assert_eq!("0.0.0.0".to_string(), subject.ip_address.unwrap());
+        assert_eq!("Mozilla/Firefox".to_string(), subject.user_agent.unwrap());
+        assert_eq!(domain_user_id, subject.domain_user_id.unwrap());
+        assert_eq!(network_user_id, subject.network_user_id.unwrap());
+        assert_eq!(session_user_id, subject.session_user_id.unwrap());
+    }
+
+    #[test]
+    fn test_build_subject_partial() {
+        let subject = Subject::builder()
+            .user_id("user_1")
+            .timezone("Europe/London")
+            .build()
+            .unwrap();
+
+        assert_eq!("user_1".to_string(), subject.user_id.unwrap());
+        assert_eq!("Europe/London".to_string(), subject.timezone.unwrap());
+        assert!(subject.language.is_none());
+        assert!(subject.ip_address.is_none());
+        assert!(subject.user_agent.is_none());
+        assert!(subject.domain_user_id.is_none());
+        assert!(subject.network_user_id.is_none());
+        assert!(subject.session_user_id.is_none());
+    }
+
+    #[test]
+    fn test_merge_subjects() {
+        let sub_with_priority = Subject::builder().user_id("user_1").build().unwrap();
+        let sub_to_merge = Subject::builder()
+            .user_id("user_2")
+            .ip_address("999.999.999.999")
+            .build()
+            .unwrap();
+
+        let merged = sub_with_priority.merge(sub_to_merge);
+
+        assert_eq!(merged.user_id.unwrap(), "user_1");
+        assert_eq!(merged.ip_address.unwrap(), "999.999.999.999");
+    }
+}

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -12,6 +12,8 @@
 use crate::emitter::Emitter;
 use crate::event::EventBuildable;
 use crate::payload::{ContextData, Payload, SelfDescribingJson};
+use crate::subject::Subject;
+
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 use uuid::Uuid;
@@ -25,27 +27,60 @@ pub struct TrackerConfig {
 /// Snowplow tracker instance used to track events to the Snowplow Collector
 pub struct Tracker {
     /// Tracker namespace that identifies the tracker within the app
-    pub namespace: String,
+    namespace: String,
     /// Application ID
-    pub app_id: String,
+    app_id: String,
     /// Emitter used to send events to the Collector
-    pub emitter: Emitter,
+    emitter: Emitter,
     /// Additional tracker config
-    pub config: TrackerConfig,
+    config: TrackerConfig,
+    /// The [Subject] that will be applied to all events
+    /// An event-level subject will take priority over this
+    subject: Subject,
 }
 
 impl Tracker {
-    pub fn new(namespace: &str, app_id: &str, emitter: Emitter) -> Tracker {
+    pub fn new(
+        namespace: &str,
+        app_id: &str,
+        emitter: Emitter,
+        subject: Option<Subject>,
+    ) -> Tracker {
         Tracker {
             namespace: namespace.to_string(),
             app_id: app_id.to_string(),
             emitter,
+            // By providing a default subject, we can avoid having to unwrap the subject
+            //
+            // The default for Subject provides `None` for all fields, so will be skipped
+            // when serializing
+            subject: subject.unwrap_or(Subject::default()),
             config: TrackerConfig {
                 platform: "pc".to_string(),
                 version: "rust-0.1.0".to_string(),
                 encode_base_64: false,
             },
         }
+    }
+
+    /// The `namespace` of this [Tracker]
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// The `app_id` of this [Tracker]
+    pub fn app_id(&self) -> &str {
+        &self.app_id
+    }
+
+    /// The [Emitter] instance of this [Tracker]
+    pub fn emitter(&self) -> &Emitter {
+        &self.emitter
+    }
+
+    /// Provides mutable access to the [Tracker] `subject` field
+    pub fn subject_mut(&mut self) -> &mut Subject {
+        &mut self.subject
     }
 
     /// Tracks a Snowplow event with optional context entities and sends it to the Snowplow collector.
@@ -71,6 +106,12 @@ impl Tracker {
             payload_builder = payload_builder.co(ContextData::new(context.to_vec()));
         }
 
+        // Event Subject gets priority over Tracker Subject
+        if let Some(event_subject) = event.subject() {
+            payload_builder =
+                payload_builder.subject(event_subject.clone().merge(self.subject.clone()));
+        }
+
         let payload = event.build_payload(payload_builder);
         if self.emitter.add(payload).await.is_ok() {
             Some(event_id)
@@ -90,13 +131,64 @@ mod tests {
             "test namespace",
             "test app id",
             Emitter::new("http://example.com/"),
+            Some(Subject {
+                user_id: Some("user_1".to_string()),
+                ..Subject::default()
+            }),
         );
 
         assert_eq!(tracker.namespace, "test namespace");
         assert_eq!(tracker.app_id, "test app id");
         assert_eq!(tracker.emitter.collector_url, "http://example.com/");
+        assert_eq!(tracker.subject.user_id.unwrap(), "user_1".to_string());
         assert_eq!(tracker.config.platform, "pc".to_string());
         assert_eq!(tracker.config.version, "rust-0.1.0".to_string());
         assert_eq!(tracker.config.encode_base_64, false);
+    }
+
+    #[test]
+    fn replace_tracker_subject() {
+        let mut tracker = Tracker::new(
+            "test namespace",
+            "test app id",
+            Emitter::new("http://example.com/"),
+            Some(Subject::builder().user_id("user_1").build().unwrap()),
+        );
+        assert_eq!(tracker.subject.user_id, Some("user_1".to_string()));
+
+        *tracker.subject_mut() = Subject::builder().user_id("user_2").build().unwrap();
+
+        assert_eq!(tracker.subject.user_id, Some("user_2".to_string()));
+    }
+
+    #[test]
+    fn update_tracker_subject() {
+        let mut tracker = Tracker::new(
+            "test namespace",
+            "test app id",
+            Emitter::new("http://example.com/"),
+            Some(
+                Subject::builder()
+                    .user_id("user_1")
+                    .ip_address("999.999.999.999")
+                    .build()
+                    .unwrap(),
+            ),
+        );
+        assert_eq!(tracker.subject.user_id, Some("user_1".to_string()));
+        assert_eq!(
+            tracker.subject.ip_address,
+            Some("999.999.999.999".to_string())
+        );
+
+        let updated_subject = Subject::builder().user_id("user_2").build().unwrap();
+
+        *tracker.subject_mut() = updated_subject.merge(tracker.subject.clone());
+
+        assert_eq!(tracker.subject.user_id, Some("user_2".to_string()));
+        assert_eq!(
+            tracker.subject.ip_address,
+            Some("999.999.999.999".to_string())
+        );
     }
 }


### PR DESCRIPTION
This PR adds `Subject` to the tracker, along with updating docs and tests. 

Subject allows you to:
- attach a subject to either a tracker to send with all events, and/or attach a subject to an event, which will take precedence over the tracker-level subject
- update/replace the tracker subject (requires taking a mutable reference to the tracker)

### Payload Tidying
The structured event fields in `Payload` have been replaced with a single instance of `Option<StructuredEvent>`. This allows us to move the serialization handling to the existing `StructuredEvent` struct by applying the `#[serde(flatten)]` attribute to the `structured_event` field of `Payload`, which (as expected) flattens the struct to inline the fields into `Payload` on serialization.
