### PR TITLE
Ensure no panics (close #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,40 +53,60 @@ To track events, simply instantiate their respective types and pass them to the 
 Please refer to the documentation for specification of event properties.
 
 ```rust
-// Tracking a screen view event
-tracker.track(
-    ScreenViewEvent::builder()
-        .id(Uuid::new_v4())
-        .name("a screen view")
-        .build()
-        .unwrap(),
-    None
-).await;
+// Tracking a Screen View event
+let screen_view_event = match ScreenViewEvent::builder()
+    .id(Uuid::new_v4())
+    .name("a screen view")
+    .previous_name("previous name")
+    .build()
+{
+    Ok(event) => event,
+    Err(e) => panic!("{e}"), // your error handling here
+};
 
-// Tracking a self-describing event with a context entity
-tracker.track(
-    SelfDescribingEvent.builder()
-        .schema("iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1"),
-        .data(json!({"targetUrl": "http://a-target-url.com"}))
-		.build()
-		.unwrap(),
-    Some(vec![
-        SelfDescribingJson::new("iglu:org.schema/WebPage/jsonschema/1-0-0", json!({"keywords": ["tester"]}))
-    ])
-).await;
+let screen_view_event_id = match tracker.track(screen_view_event, None).await {
+    Ok(uuid) => uuid,
+    Err(e) => panic!("{e}"), // your error handling here
+};
 
-// Tracking a structured event
-tracker.track(
-    StructuredEvent::builder()
-        .category("shop")
-        .action("add-to-basket")
-        .label("Add To Basket")
-        .property("pcs")
-        .value(2.0)
-        .build()
-        .unwrap(),
-    None
-).await
+// Tracking a Self-Describing event with context entity
+let self_describing_event = match SelfDescribingEvent::builder()
+    .schema("iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0")
+    .data(json!({"name": "test", "id": "something else"}))
+    .build()
+{
+    Ok(event) => event,
+    Err(e) => panic!("{e}"), // your error handling here
+};
+
+let event_context = Some(vec![SelfDescribingJson::new(
+    "iglu:org.schema/WebPage/jsonschema/1-0-0",
+    json!({"keywords": ["tester"]}),
+)]);
+
+let self_desc_event_id = match tracker.track(self_describing_event, event_context).await {
+    Ok(uuid) => uuid,
+    Err(e) => panic!("{e}"), // your error handling here
+};
+
+
+// Tracking a Structured event
+let structured_event = match StructuredEvent::builder()
+    .category("shop")
+    .action("add-to-basket")
+    .label("Add To Basket")
+    .property("pcs")
+    .value(2.0)
+    .build()
+{
+    Ok(event) => event,
+    Err(e) => panic!("{e}"), // your error handling here
+};
+
+let struct_event_id = match tracker.track(structured_event, None).await {
+    Ok(uuid) => uuid,
+    Err(e) => panic!("{e}"), // your error handling here
+};
 ```
 
 ## Find Out More

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -9,7 +9,7 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 
-use crate::payload::Payload;
+use crate::{payload::Payload, Error};
 use reqwest::Client;
 use serde_json::json;
 
@@ -28,15 +28,11 @@ impl Emitter {
     }
 
     /// Add event to be sent to the Collector
-    pub async fn add(&self, payload: Payload) -> Result<(), reqwest::Error> {
-        let result = self.post(payload).await;
-        match result {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        }
+    pub async fn add(&self, payload: Payload) -> Result<(), Error> {
+        self.post(payload).await
     }
 
-    async fn post(&self, payload: Payload) -> Result<String, reqwest::Error> {
+    async fn post(&self, payload: Payload) -> Result<(), Error> {
         let collector_url = self.collector_url.to_string() + "/com.snowplowanalytics.snowplow/tp2";
 
         let payload = json!({
@@ -44,13 +40,15 @@ impl Emitter {
             "data": vec![payload]
         });
 
-        let resp = self
+        match self
             .http_client
             .post(collector_url)
             .json(&payload)
             .send()
-            .await?;
-
-        resp.text().await
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(e) => Err(Error::EmitterError(e.to_string())),
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+use std::fmt::{Display, Formatter, Result};
+
+/// The errors that can occur when using the Snowplow Tracker
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// An error occurred when trying to build an event or payload
+    BuilderError(String),
+    /// An error occurred when trying to emit an event
+    EmitterError(String),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self {
+            Error::BuilderError(builder_err) => write!(f, "{}", builder_err),
+            Error::EmitterError(emitter_err) => write!(f, "{}", emitter_err),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+// This allows us to use `#[builder(build_fn(error = "Error"))]` on builders
+// to return `Error` instead of `UninitializedFieldError`
+impl From<derive_builder::UninitializedFieldError> for Error {
+    fn from(e: derive_builder::UninitializedFieldError) -> Error {
+        Error::BuilderError(e.to_string())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,36 +15,51 @@
 //!
 //! ## Example usage
 //!
-//! ```
 //! use snowplow_tracker::{Snowplow, SelfDescribingJson, SelfDescribingEvent, Subject};
 //! use serde_json::json;
 //!
 //! // Initialize a tracker instance given a namespace, application ID, Snowplow collector URL, and
 //! // Subject
 //!
-//! let subject = Subject::builder().language("en-gb").build().unwrap();
-//! let tracker = Snowplow::create_tracker("ns", "app_id", "https://...", Some(subject));
+//! let tracker_subject = match Subject::builder().language("en-gb").build() {
+//!     Ok(subject) => subject,
+//!     Err(e) => panic!("{e}"), // your error handling here
+//! };
 //!
-//! // Tracking a self-describing event with a context entity
-//! tracker.track(
-//!     SelfDescribingEvent::builder()
-//!         .schema("iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1")
-//!         .data(json!({"targetUrl": "http://a-target-url.com"}))
-//!         .subject(
-//!             Subject::builder()
-//!             .user_id("user_1")
-//!             .build()
-//!             .unwrap()
-//!         )
-//!         .build()
-//!         .unwrap(),
-//!     Some(vec![
-//!         SelfDescribingJson::new("iglu:org.schema/WebPage/jsonschema/1-0-0", json!({"keywords": ["tester"]}))
-//!     ]),
-//! );
-//! ```
+//! let tracker = Snowplow::create_tracker("ns", "app_id", "https://...", Some(tracker_subject));
+//!
+//!
+//! // Tracking a self-describing event with a context entity and subject
+//! let event_subject = match Subject::builder().language("en-gb").build() {
+//!     Ok(subject) => subject,
+//!     Err(e) => panic!("{e}"), // your error handling here
+//! };
+//!
+//! let self_describing_event_build = match SelfDescribingEvent::builder()
+//!     .schema("iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1")
+//!     .data(json!({"targetUrl": "http://a-target-url.com"}))
+//!     .subject(event_subject)
+//! {
+//!     Ok(event) => event,
+//!     Err(e) => panic!("{e}"), // your error handling here
+//! };
+//!
+//! let context = Some(vec![SelfDescribingJson::new(
+//!     "iglu:org.schema/WebPage/jsonschema/1-0-0",
+//!     json!({"keywords": ["tester"]}),
+//! ]));
+//!
+//! let self_desc_event_id = match tracker.track(
+//!     self_describing_event,
+//!     context,
+//! ) {
+//!     Ok(id) => id,
+//!     Err(e) => panic!("{e}"), // your error handling here
+//! }
+//!
 
 mod emitter;
+mod error;
 mod event;
 mod payload;
 mod snowplow;
@@ -52,6 +67,7 @@ mod subject;
 mod tracker;
 
 pub use emitter::Emitter;
+pub use error::Error;
 pub use event::ScreenViewEvent;
 pub use event::SelfDescribingEvent;
 pub use event::StructuredEvent;

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::Value;
 
+use crate::Error;
 use crate::StructuredEvent;
 use crate::Subject;
 
@@ -29,6 +30,7 @@ pub enum EventType {
 #[builder(field(public))]
 #[builder(pattern = "owned")]
 #[builder(setter(strip_option))]
+#[builder(build_fn(error = "Error"))]
 pub struct Payload {
     p: String,
     tv: String,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -240,7 +240,8 @@ async fn track_self_describing_event() {
                 json!({"keywords": ["tester"]}),
             )]),
         )
-        .await;
+        .await
+        .unwrap();
 
     let good_events = micro_endpoint(&micro_url, "good").await;
     let received_event = good_events.as_array().unwrap().last().unwrap();


### PR DESCRIPTION
This PR removes any runtime panics that could happen within the library. This involved creating an `Error` Enum, as a return type for possible failures, and changing our return types to `Result<T, Error>`
Docs have also been updated to reflect new expected usage of functions that return `Result`.

There are currently two errors in the Enum:
### `BuilderError`
This, using the `#[builder(build_fn(error = "Error"))]` attribute on builder structs, handles errors that occur at any point during the building events or payloads.

 It also handles a single [other case](https://github.com/snowplow-incubator/snowplow-rust-tracker/compare/release/0.1.0...issue/15-ensure_no_panics?expand=1#diff-13e8b158f84f88059e0bd8631dfa9113112e30d7b8c21a15413d0ef36d2ea180R97) in `Tracker.track` while finalising the building of the payload, where we attempt to get the current time. I'm not 100% sure the usage there is appropriate, but introducing a new Enum member to handle only this case felt a bit overkill. It can be expanded out in future if required.

### `EmitterError`
This handles any errors that can occur in the emitter. It currently only exists in `Emitter.post`, but will likely be expanded as the emitter is built out.

