### PR TITLE
Improve package docs (close #17)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ description = "A package for tracking Snowplow events in Rust apps"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
+homepage = "https://snowplow.io"
+repository = "https://github.com/snowplow/snowplow-rust-tracker"
+keywords = ["snowplow", "tracker", "analytics"]
 
 [dependencies]
 reqwest = { version = "0.11", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status][gh-actions-image]][gh-actions]
 [![License][license-image]][license]
 
-Snowplow is a scalable open-source platform for rich, high quality, low-latency data collection. It is designed to collect high quality, complete behavioral data for enterprise business.
+Snowplow is a scalable open-source platform for rich, high-quality, low-latency data collection. It is designed to collect high-quality, complete behavioral data for enterprise business.
 
 **To find out more, please check out the [Snowplow website][website] and our [documentation][docs].**
 
@@ -61,12 +61,12 @@ let screen_view_event = match ScreenViewEvent::builder()
     .build()
 {
     Ok(event) => event,
-    Err(e) => panic!("{e}"), // your error handling here
+    Err(e) => panic!("ScreenViewEvent could not be built: {e}"), // your error handling here
 };
 
 let screen_view_event_id = match tracker.track(screen_view_event, None).await {
     Ok(uuid) => uuid,
-    Err(e) => panic!("{e}"), // your error handling here
+    Err(e) => panic!("Failed to emit event: {e}"), // your error handling here
 };
 
 // Tracking a Self-Describing event with context entity
@@ -76,7 +76,7 @@ let self_describing_event = match SelfDescribingEvent::builder()
     .build()
 {
     Ok(event) => event,
-    Err(e) => panic!("{e}"), // your error handling here
+    Err(e) => panic!("SelfDescribingEvent could not be built: {e}"), // your error handling here
 };
 
 let event_context = Some(vec![SelfDescribingJson::new(
@@ -86,7 +86,7 @@ let event_context = Some(vec![SelfDescribingJson::new(
 
 let self_desc_event_id = match tracker.track(self_describing_event, event_context).await {
     Ok(uuid) => uuid,
-    Err(e) => panic!("{e}"), // your error handling here
+    Err(e) => panic!("Failed to emit event: {e}"), // your error handling here
 };
 
 
@@ -100,26 +100,26 @@ let structured_event = match StructuredEvent::builder()
     .build()
 {
     Ok(event) => event,
-    Err(e) => panic!("{e}"), // your error handling here
+    Err(e) => panic!("StructuredEvent could not be built: {e}"), // your error handling here
 };
 
 let struct_event_id = match tracker.track(structured_event, None).await {
     Ok(uuid) => uuid,
-    Err(e) => panic!("{e}"), // your error handling here
+    Err(e) => panic!("Failed to emit event: {e}"), // your error handling here
 };
 ```
 
 ## Find Out More
 
 | Technical Docs                    | Setup Guide                 |
-|-----------------------------------|-----------------------------|
+| --------------------------------- | --------------------------- |
 | [![i1][techdocs-image]][techdocs] | [![i2][setup-image]][setup] |
 | [Technical Docs][techdocs]        | [Setup Guide][setup]        |
 
 ## Maintainers
 
 | Contributing                                 |
-|----------------------------------------------|
+| -------------------------------------------- |
 | [![i4][contributing-image]](CONTRIBUTING.md) |
 | [Contributing](CONTRIBUTING.md)              |
 
@@ -143,8 +143,8 @@ limitations under the License.
 [docs]: https://docs.snowplow.io/
 [rust-docs]: https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/rust-tracker/
 
-[gh-actions]: https://github.com/snowplow-incubator/snowplow-rust-tracker/actions/workflows/build.yml
-[gh-actions-image]: https://github.com/snowplow-incubator/snowplow-rust-tracker/actions/workflows/build.yml/badge.svg
+[gh-actions]: https://github.com/snowplow/snowplow-rust-tracker/actions/workflows/ci.yml
+[gh-actions-image]: https://github.com/snowplow/snowplow-rust-tracker/actions/workflows/ci.yml/badge.svg
 
 [license]: https://www.apache.org/licenses/LICENSE-2.0
 [license-image]: https://img.shields.io/badge/license-Apache--2-blue.svg?style=flat

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -13,12 +13,13 @@ use crate::{payload::Payload, Error};
 use reqwest::Client;
 use serde_json::json;
 
+/// A component of a [Tracker](crate::Tracker), responsible for sending events to the Snowplow Collector
 pub struct Emitter {
+    /// The URL of your Snowplow [Collector](https://docs.snowplow.io/docs/pipeline-components-and-applications/stream-collector/)
     pub collector_url: String,
     http_client: Client,
 }
 
-/// Emitter is responsible for emitting tracked events to the Snowplow Collector
 impl Emitter {
     pub fn new(collector_url: &str) -> Emitter {
         Emitter {

--- a/src/event.rs
+++ b/src/event.rs
@@ -44,6 +44,7 @@ pub struct SelfDescribingEvent {
     /// This data must conform to the schema specified in the schema argument, or the event will fail validation and land in bad rows.
     pub data: Value,
 
+    /// The [Subject] of the event.
     #[builder(default)]
     #[serde(skip_serializing)]
     pub subject: Option<Subject>,
@@ -111,6 +112,7 @@ pub struct StructuredEvent {
     #[serde(serialize_with = "optional_f64_to_string")]
     pub value: Option<f64>,
 
+    /// The [Subject] of the event.
     #[builder(default)]
     #[serde(skip_serializing)]
     pub subject: Option<Subject>,
@@ -188,6 +190,7 @@ pub struct ScreenViewEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transition_type: Option<String>,
 
+    /// The [Subject] of the event.
     #[builder(default)]
     #[serde(skip_serializing)]
     pub subject: Option<Subject>,
@@ -234,6 +237,7 @@ pub struct TimingEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
 
+    /// The [Subject] of the event.
     #[builder(default)]
     #[serde(skip_serializing)]
     pub subject: Option<Subject>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,54 +9,49 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 
-//! # Snowplow Rust Tracker
+//! # Snowplow Tracker
 //!
-//! The Snowplow Rust Tracker allows you to track Snowplow events in your Rust applications.
+//! The [Snowplow](https://snowplow.io) Rust Tracker allows you to track Snowplow events in your Rust applications.
+//! For information on how to effectively design tracking using Snowplow, visit our [guide on tracking design.](https://docs.snowplow.io/docs/understanding-tracking-design/)
 //!
 //! ## Example usage
 //!
-//! use snowplow_tracker::{Snowplow, SelfDescribingJson, SelfDescribingEvent, Subject};
+//! This simple example shows the process of creating a Tracker, and then building and tracking a [Self-Describing Event](crate::SelfDescribingEvent), using the [`link_click`](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1)
+//! Iglu schema URI, and schema-confirming JSON data.
+//!
+//! ```
+//! use snowplow_tracker::{SelfDescribingEvent, Snowplow, Subject};
 //! use serde_json::json;
 //!
-//! // Initialize a tracker instance given a namespace, application ID, Snowplow collector URL, and
-//! // Subject
+//! #[tokio::main]
+//! async fn main() {
+//!     // Build a Subject that will be attached to all events sent by this tracker
+//!     let tracker_subject = match Subject::builder().language("en-gb").build() {
+//!         Ok(subject) => subject,
+//!         Err(e) => panic!("Subject could not be built: {e}"), // your error handling here
+//!     };
 //!
-//! let tracker_subject = match Subject::builder().language("en-gb").build() {
-//!     Ok(subject) => subject,
-//!     Err(e) => panic!("{e}"), // your error handling here
-//! };
+//!     // Create a tracker
+//!     let tracker = Snowplow::create_tracker("ns", "app_id", "https://example.com", Some(tracker_subject));
 //!
-//! let tracker = Snowplow::create_tracker("ns", "app_id", "https://...", Some(tracker_subject));
+//!     // Build a Self-Describing Event, with the schema of the event we want to track, along
+//!     // with relevent, schema-conforming, data
+//!     let self_describing_event = match SelfDescribingEvent::builder()
+//!         .schema("iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1")
+//!         .data(json!({"targetUrl": "http://example.com/some-page"}))
+//!         .build()
+//!     {
+//!         Ok(event) => event,
+//!         Err(e) => panic!("SelfDescribingEvent could not be built: {e}"), // your error handling here
+//!     };
 //!
-//!
-//! // Tracking a self-describing event with a context entity and subject
-//! let event_subject = match Subject::builder().language("en-gb").build() {
-//!     Ok(subject) => subject,
-//!     Err(e) => panic!("{e}"), // your error handling here
-//! };
-//!
-//! let self_describing_event_build = match SelfDescribingEvent::builder()
-//!     .schema("iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1")
-//!     .data(json!({"targetUrl": "http://a-target-url.com"}))
-//!     .subject(event_subject)
-//! {
-//!     Ok(event) => event,
-//!     Err(e) => panic!("{e}"), // your error handling here
-//! };
-//!
-//! let context = Some(vec![SelfDescribingJson::new(
-//!     "iglu:org.schema/WebPage/jsonschema/1-0-0",
-//!     json!({"keywords": ["tester"]}),
-//! ]));
-//!
-//! let self_desc_event_id = match tracker.track(
-//!     self_describing_event,
-//!     context,
-//! ) {
-//!     Ok(id) => id,
-//!     Err(e) => panic!("{e}"), // your error handling here
+//!     // Track our Self-Describing Event
+//!     let self_desc_event_uuid = match tracker.track(self_describing_event, None).await {
+//!         Ok(uuid) => uuid,
+//!         Err(e) => panic!("Failed to emit event: {e}"), // your error handling here
+//!     };
 //! }
-//!
+//! ```
 
 mod emitter;
 mod error;

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -13,6 +13,7 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::Value;
+use uuid::Uuid;
 
 use crate::Error;
 use crate::StructuredEvent;
@@ -31,10 +32,13 @@ pub enum EventType {
 #[builder(pattern = "owned")]
 #[builder(setter(strip_option))]
 #[builder(build_fn(error = "Error"))]
+/// The final payload that is sent to the collector
+///
+/// For more information, see the [Snowplow Tracker Protocol](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol)
 pub struct Payload {
     p: String,
     tv: String,
-    pub eid: uuid::Uuid,
+    eid: Uuid,
     dtm: String,
     stm: String,
 

--- a/src/snowplow.rs
+++ b/src/snowplow.rs
@@ -13,11 +13,11 @@ use crate::emitter::Emitter;
 use crate::subject::Subject;
 use crate::tracker::Tracker;
 
+/// Main interface for the package, used to initialize trackers.
 pub struct Snowplow;
 
-/// Main interface for the package used to initialize trackers.
 impl Snowplow {
-    /// Creates a new Tracker instance that can be used to track events
+    /// Creates a new [Tracker] instance
     pub fn create_tracker(
         namespace: &str,
         app_id: &str,

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -13,10 +13,11 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// Subject allows you to attach additional information about your application's environment
+/// Subject allows you to attach additional information about your application's environment.
 ///
-/// A Subject can be (attached to either a Tracker) where it will be sent with every Event, and/or
-/// attached to an Event, with the Event-level subject taking priority over Tracker-level
+/// A Subject can be attached to:
+/// - A [crate::Tracker], where it will be sent with every Event
+/// - An Event itself, with the Event-level Subject fields taking priority over Tracker-level (if present)
 #[derive(Serialize, Deserialize, Builder, Default, Clone, Debug)]
 #[builder(setter(into, strip_option), default)]
 pub struct Subject {
@@ -84,6 +85,21 @@ impl Subject {
     }
 
     /// Merges another instance of [Subject], with self taking priority
+    ///
+    /// Also useful in conjunction with [Tracker.subject_mut](crate::Tracker::subject_mut) to update the subject field, without replacing
+    ///
+    /// ## Example
+    /// ```
+    /// use snowplow_tracker::Subject;
+    ///
+    /// let priority_subject = Subject::builder().user_id("user_1").build().unwrap();
+    /// let subject_to_merge = Subject::builder().user_id("user_2").language("en-gb").build().unwrap();
+    ///
+    /// let merged_subject = priority_subject.merge(subject_to_merge);
+    ///
+    /// assert_eq!(merged_subject.user_id, Some("user_1".to_string()));
+    /// assert_eq!(merged_subject.language, Some("en-gb".to_string()));
+    ///```
     pub fn merge(self, other: Subject) -> Self {
         Self {
             user_id: self.user_id.or(other.user_id),

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -25,7 +25,7 @@ pub struct TrackerConfig {
     pub encode_base_64: bool,
 }
 
-/// Snowplow tracker instance used to track events to the Snowplow Collector
+/// The Snowplow tracker, used to track events
 pub struct Tracker {
     /// Tracker namespace that identifies the tracker within the app
     namespace: String,
@@ -41,6 +41,7 @@ pub struct Tracker {
 }
 
 impl Tracker {
+    /// Creates a new Tracker instance
     pub fn new(
         namespace: &str,
         app_id: &str,
@@ -64,22 +65,52 @@ impl Tracker {
         }
     }
 
-    /// The `namespace` of this [Tracker]
     pub fn namespace(&self) -> &str {
         &self.namespace
     }
 
-    /// The `app_id` of this [Tracker]
     pub fn app_id(&self) -> &str {
         &self.app_id
     }
 
-    /// The [Emitter] instance of this [Tracker]
     pub fn emitter(&self) -> &Emitter {
         &self.emitter
     }
 
-    /// Provides mutable access to the [Tracker] `subject` field
+    pub fn subject(&self) -> &Subject {
+        &self.subject
+    }
+
+    /// Provides mutable access to the `subject` field
+    ///
+    /// ## Example
+    /// ```
+    /// use snowplow_tracker::{Snowplow, Subject};
+    ///
+    /// // Build a Subject that will be attached to this tracker
+    /// let tracker_subject = match Subject::builder().user_id("user_1").language("en-gb").build() {
+    ///     Ok(subject) => subject,
+    ///     Err(e) => panic!("Subject could not be built: {e}"), // your error handling here
+    /// };
+    ///
+    /// // Create a tracker with attached Subject
+    /// let mut tracker = Snowplow::create_tracker("ns", "app_id", "https://...", Some(tracker_subject));
+    ///
+    /// assert_eq!(tracker.subject().user_id, Some("user_1".to_string()));
+    /// assert_eq!(tracker.subject().language, Some("en-gb".to_string()));
+    ///
+    /// // Bulild a new Subject to replace the instance in `tracker`
+    /// let new_tracker_subject = match Subject::builder().user_id("user_2").build() {
+    ///     Ok(subject) => subject,
+    ///     Err(e) => panic!("Subject could not be built: {e}"), // your error handling here
+    /// };
+    ///
+    /// // We must dereference here to assign to the mutably borrowed value
+    /// *tracker.subject_mut() = new_tracker_subject;
+    ///
+    /// assert_eq!(tracker.subject().user_id, Some("user_2".to_string()));
+    /// assert_eq!(tracker.subject().language, None);
+    /// ```
     pub fn subject_mut(&mut self) -> &mut Subject {
         &mut self.subject
     }


### PR DESCRIPTION
Various docs changes, mostly focused around improving what will be generated for docs.rs/crates.io once we deploy the package. 

- add `homepage`, `repository`, and `keywords` to `Cargo.toml`
- fix `Build Status` badge
- update example in `lib.rs`
- add/update docstrings and provide examples
- remove `pub` from eid and `use uuid::Uuid` at top, as in other files

To view a local version of the generated docs, run `cargo doc --no-deps --open` in the root directory
