### PR TITLE
Add Cargo Audit (close #26)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,13 @@
+[advisories]
+ignore = ["RUSTSEC-2020-0071"]
+# RUSTSEC-2020-0071 is picked up due to the following dependency tree:
+#
+# time 0.1.44
+# └── chrono 0.4.22
+#     └── bollard-stubs 1.41.0
+#         └── testcontainers 0.14.0
+#             └── snowplow_tracker 0.1.0
+#
+# We can safely ignore this though, as `bollard-stubs` is an optional dependency of `testcontainers`,
+# which is only enabled if using the "experiemental" feature (which we aren't):
+# https://github.com/testcontainers/testcontainers-rs/blob/dev/testcontainers/Cargo.toml#L32

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,24 @@
+# This workflow respects the configuration for `cargo audit` in `.cargo/audit.toml`
+name: Security Audit
+
+on:
+  # Run on push if Cargo toml/lock has changed
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+
+  # Run every day at 00:00
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added the `audit-check` [action](https://github.com/actions-rs/audit-check) to check for security advisories on push if `Cargo.toml` and/or `Cargo.lock` have changed, along with running every day at 00:00

If a new advisory is detected, an issue will automatically be created in the repo.