### PR TITLE
Add Logging (close #28)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "derive_builder",
+ "log",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0.82"
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 derive_builder = "0.11.2"
 async-trait = "0.1.58"
+log = "0.4.17"
 
 [dev-dependencies]
 testcontainers = "0.14.0"

--- a/src/http_client/reqwest_client.rs
+++ b/src/http_client/reqwest_client.rs
@@ -39,12 +39,16 @@ impl HttpClient for ReqwestClient {
         match self.client.post(&collector_url).json(&payload).send().await {
             Ok(resp) => match resp.status().is_success() {
                 true => Ok(()),
-                false => Err(Error::EmitterError(format!(
-                    "Error sending request: {}",
-                    resp.status()
-                ))),
+                false => {
+                    log::error!("POST request failed with code: {}", resp.status());
+
+                    Err(Error::EmitterError(format!(
+                        "POST request failed with code: {}",
+                        resp.status()
+                    )))
+                }
             },
-            Err(e) => Err(Error::EmitterError(e.to_string())),
+            Err(e) => Err(Error::EmitterError(format!("POST request failed: {e}"))),
         }
     }
 


### PR DESCRIPTION
This PR adds logging using the [log](https://crates.io/crates/log) crate, along with adding some light logging throughout batch emitter and reqwest client. 

To view the logging output you will have to use a logging consumer, such as [pretty env logger](https://github.com/seanmonstar/pretty-env-logger).

Other changes:
- address TODO to replace `println` with logging in batch emitter
- update Err message in `reqwest_client` to be a bit clearer and in-line with logging