### PR TITLE
Add Retry (close #30)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,11 +288,10 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -547,11 +546,10 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -616,12 +614,6 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -747,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project-lite"
@@ -1009,6 +1001,7 @@ dependencies = [
  "async-trait",
  "derive_builder",
  "log",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",
@@ -1109,9 +1102,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1119,7 +1112,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -1222,13 +1214,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ uuid = { version = "1.1.2", features = ["v4", "serde"] }
 derive_builder = "0.11.2"
 async-trait = "0.1.58"
 log = "0.4.17"
+rand = "0.8.5"
 
 [dev-dependencies]
 testcontainers = "0.14.0"

--- a/src/emitter/retry_policy.rs
+++ b/src/emitter/retry_policy.rs
@@ -9,10 +9,15 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 
-mod batch_emitter;
-mod emitter;
-mod retry_policy;
-
-pub use batch_emitter::BatchEmitter;
-pub use emitter::Emitter;
-pub use retry_policy::RetryPolicy;
+#[derive(Debug, Copy, Clone)]
+/// Retry policy for the [BatchEmitter](crate::emitter::BatchEmitter).
+///
+/// This can be used to configure how an the emitter should handle failed requests.
+pub enum RetryPolicy {
+    /// Retry sending events forever
+    RetryForever,
+    /// Retry sending events until the maximum number of retries is reached
+    MaxRetries(u32),
+    /// Do not retry sending events
+    NoRetry,
+}

--- a/src/event_batch.rs
+++ b/src/event_batch.rs
@@ -9,9 +9,13 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 
-use serde_json::json;
+use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
 
-use crate::{payload::Payload, SelfDescribingJson};
+use rand::Rng;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::{emitter::RetryPolicy, payload::Payload, Error, SelfDescribingJson};
 
 const PAYLOAD_DATA_SCHEMA: &str =
     "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4";
@@ -19,15 +23,168 @@ const PAYLOAD_DATA_SCHEMA: &str =
 /// A batch of events to be sent to the collector.
 #[derive(Debug)]
 pub struct EventBatch {
+    pub id: Uuid,
     pub events: Vec<Payload>,
+    pub delay: Option<Duration>,
+    pub retry_attempts: u32,
 }
 
 impl EventBatch {
+    pub fn new(id: Uuid, events: Vec<Payload>) -> Self {
+        Self {
+            id,
+            events,
+            delay: None,
+            retry_attempts: 0,
+        }
+    }
+
     /// Creates a sendable payload from the batch.
     pub fn as_payload(&self) -> SelfDescribingJson {
         SelfDescribingJson {
             schema: PAYLOAD_DATA_SCHEMA.to_string(),
             data: json!(self.events),
         }
+    }
+
+    /// Whether the batch has any retries remaining.
+    pub fn has_retry(&self, retry_policy: RetryPolicy) -> bool {
+        match retry_policy {
+            RetryPolicy::NoRetry => false,
+            RetryPolicy::MaxRetries(n) => self.retry_attempts < n,
+            RetryPolicy::RetryForever => true,
+        }
+    }
+
+    /// Updates the events `stm` field in batch with the current time.
+    pub fn update_event_stm(&mut self) -> Result<(), Error> {
+        let since_the_epoch =
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e: SystemTimeError| {
+                    Error::BuilderError(format!("Failed to get current time: {}", e.to_string()))
+                })?;
+
+        for event in self.events.iter_mut() {
+            event.stm = since_the_epoch.as_millis().to_string();
+        }
+
+        Ok(())
+    }
+
+    /// Updates the delay until another sending attempt is made.
+    pub fn update_for_retry(&mut self) {
+        let max_event_delay_time = Duration::from_secs(600_000);
+
+        self.retry_attempts += 1;
+
+        self.delay = match self.delay {
+            Some(delay) => {
+                // 2 +- random number between 0 and 1
+                let delay_mul = rand::thread_rng().gen_range(1.0..=3.0);
+
+                Some(delay.mul_f32(delay_mul).min(max_event_delay_time))
+            }
+            None => Some(Duration::from_secs(1)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use uuid::Uuid;
+
+    use crate::emitter::RetryPolicy;
+    use crate::PayloadBuilder;
+    use crate::{event_batch::EventBatch, payload::Payload};
+
+    fn create_payloads(n: usize) -> Vec<PayloadBuilder> {
+        (0..n)
+            .map(|_| {
+                Payload::builder()
+                    .p("p".to_string())
+                    .tv("tv".to_string())
+                    .eid(Uuid::new_v4())
+                    .dtm("dtm".to_string())
+                    .stm("stm".to_string())
+                    .aid("aid".to_string())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn update_event_stm() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+
+        let mut batch = EventBatch::new(
+            Uuid::new_v4(),
+            create_payloads(5)
+                .drain(..)
+                .map(|p| p.finalise_payload().unwrap())
+                .collect(),
+        );
+
+        std::thread::sleep(Duration::from_secs(1));
+
+        batch.update_event_stm().unwrap();
+
+        for event in batch.events.iter() {
+            let event_stm = Duration::from_millis(event.stm.parse::<u64>().unwrap());
+            assert!(event_stm > now);
+        }
+    }
+
+    #[test]
+    fn update_batch_delay() {
+        let mut batch = EventBatch::new(
+            Uuid::new_v4(),
+            create_payloads(5)
+                .drain(..)
+                .map(|p| p.finalise_payload().unwrap())
+                .collect(),
+        );
+
+        std::thread::sleep(Duration::from_secs(1));
+
+        batch.update_for_retry();
+
+        assert!(batch.delay.unwrap() > Duration::from_secs(0));
+    }
+
+    #[test]
+    fn no_retry_policy() {
+        let batch = EventBatch::new(
+            Uuid::new_v4(),
+            create_payloads(5)
+                .drain(..)
+                .map(|p| p.finalise_payload().unwrap())
+                .collect(),
+        );
+
+        assert!(!batch.has_retry(RetryPolicy::NoRetry));
+    }
+
+    #[test]
+    fn limited_retry_policy() {
+        let mut batch = EventBatch::new(
+            Uuid::new_v4(),
+            create_payloads(5)
+                .drain(..)
+                .map(|p| p.finalise_payload().unwrap())
+                .collect(),
+        );
+        let policy = RetryPolicy::MaxRetries(5);
+
+        assert!(batch.has_retry(policy));
+
+        for _ in 0..5 {
+            batch.update_for_retry();
+        }
+
+        assert!(!batch.has_retry(policy));
     }
 }

--- a/src/event_store/event_store.rs
+++ b/src/event_store/event_store.rs
@@ -9,6 +9,8 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 
+use uuid::Uuid;
+
 use crate::error::Error;
 use crate::event_batch::EventBatch;
 use crate::payload::PayloadBuilder;
@@ -30,4 +32,6 @@ pub trait EventStore {
     fn full_batch(&mut self) -> Result<EventBatch, Error>;
     /// Removes and returns the provided number of events from the EventStore as an [EventBatch]
     fn batch_of(&mut self, size: usize) -> Result<EventBatch, Error>;
+    // A method to be called after attempts to send are finished, either successfully or unsuccessfully
+    fn cleanup_after_send_attempt(&mut self, batch_id: Uuid) -> Result<(), Error>;
 }

--- a/src/http_client/http_client.rs
+++ b/src/http_client/http_client.rs
@@ -22,7 +22,7 @@ use crate::Error;
 #[async_trait]
 pub trait HttpClient {
     /// Send a [SelfDescribingJson] to the collector via POST
-    async fn post(&self, payload: SelfDescribingJson) -> Result<(), Error>;
+    async fn post(&self, payload: SelfDescribingJson) -> Result<u16, Error>;
     /// Duplicate the HttpClient
     fn clone(&self) -> Box<dyn HttpClient + Send + Sync>;
 }

--- a/src/http_client/reqwest_client.rs
+++ b/src/http_client/reqwest_client.rs
@@ -33,21 +33,11 @@ impl ReqwestClient {
 
 #[async_trait]
 impl HttpClient for ReqwestClient {
-    async fn post(&self, payload: SelfDescribingJson) -> Result<(), Error> {
+    async fn post(&self, payload: SelfDescribingJson) -> Result<u16, Error> {
         let collector_url = format!("{}/{}", self.collector_url, POST_PATH);
 
         match self.client.post(&collector_url).json(&payload).send().await {
-            Ok(resp) => match resp.status().is_success() {
-                true => Ok(()),
-                false => {
-                    log::error!("POST request failed with code: {}", resp.status());
-
-                    Err(Error::EmitterError(format!(
-                        "POST request failed with code: {}",
-                        resp.status()
-                    )))
-                }
-            },
+            Ok(resp) => Ok(resp.status().as_u16()),
             Err(e) => Err(Error::EmitterError(format!("POST request failed: {e}"))),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ mod snowplow;
 mod subject;
 mod tracker;
 
-pub use emitter::{BatchEmitter, Emitter};
+pub use emitter::{BatchEmitter, Emitter, RetryPolicy};
 pub use error::Error;
 pub use event::{ScreenViewEvent, SelfDescribingEvent, StructuredEvent, TimingEvent};
 pub use event_store::{EventStore, InMemoryEventStore};

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -34,6 +34,7 @@ pub enum EventType {
 #[builder(pattern = "owned")]
 #[builder(setter(strip_option))]
 #[builder(build_fn(error = "Error"))]
+#[builder(derive(Clone))]
 /// The final payload that is sent to the collector
 ///
 /// For more information, see the [Snowplow Tracker Protocol](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol)
@@ -42,7 +43,7 @@ pub struct Payload {
     tv: String,
     pub(crate) eid: Uuid,
     dtm: String,
-    stm: String,
+    pub(crate) stm: String,
 
     #[builder(default)]
     e: Option<EventType>,

--- a/tests/common/common.rs
+++ b/tests/common/common.rs
@@ -29,14 +29,19 @@ pub fn setup(docker: &Cli) -> (Container<Micro>, String) {
 }
 
 pub async fn wait_for_events(micro_url: &str, page: &str, number: usize) {
+    let timeout = std::time::Instant::now() + std::time::Duration::from_secs(30);
     loop {
+        if timeout < std::time::Instant::now() {
+            panic!("Timeout waiting for events");
+        }
+
         let response = micro_endpoint(micro_url, page).await;
         match response.as_array() {
             Some(events) => {
                 if events.len() >= number {
                     break;
                 } else {
-                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                 }
             }
             _ => tokio::time::sleep(std::time::Duration::from_millis(100)).await,

--- a/tests/common/flakey_http_client.rs
+++ b/tests/common/flakey_http_client.rs
@@ -1,0 +1,66 @@
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use snowplow_tracker::{HttpClient, SelfDescribingJson};
+use testcontainers::clients::Cli;
+
+use crate::common::setup;
+
+pub struct FlakeyHttpClient {
+    pub micro_url: String,
+    pub count: Arc<AtomicUsize>,
+    pub number_of_events_to_block: usize,
+}
+
+#[async_trait::async_trait]
+impl HttpClient for FlakeyHttpClient {
+    async fn post(&self, payload: SelfDescribingJson) -> Result<u16, snowplow_tracker::Error> {
+        if self.count.load(Ordering::SeqCst) < self.number_of_events_to_block {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            return Ok(500);
+        } else {
+            let client = reqwest::Client::new();
+            Ok(client
+                .post(&(self.micro_url.to_string() + "/com.snowplowanalytics.snowplow/tp2"))
+                .json(&payload)
+                .send()
+                .await
+                .unwrap()
+                .status()
+                .as_u16())
+        }
+    }
+
+    fn clone(&self) -> Box<dyn HttpClient + Send + Sync> {
+        Box::new(FlakeyHttpClient {
+            count: self.count.clone(),
+            number_of_events_to_block: self.number_of_events_to_block,
+            micro_url: self.micro_url.clone(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn flaky_http_client_returns_500_n_times() {
+    let docker = Cli::default();
+    let (_container, micro_url) = setup(&docker);
+
+    let client = FlakeyHttpClient {
+        micro_url: micro_url.to_string(),
+        count: Arc::new(AtomicUsize::new(0)),
+        number_of_events_to_block: 5,
+    };
+
+    let sdj = SelfDescribingJson {
+        schema: String::new(),
+        data: serde_json::json!({}),
+    };
+
+    for _ in 0..5 {
+        assert_eq!(client.post(sdj.clone()).await.unwrap(), 500);
+    }
+
+    assert_eq!(client.post(sdj.clone()).await.unwrap(), 200);
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,7 @@
 mod common;
+mod flakey_http_client;
 mod micro;
 
 pub use common::{micro_endpoint, setup, wait_for_events};
+pub use flakey_http_client::FlakeyHttpClient;
 pub use micro::Micro;

--- a/tests/test_batch_emitter.rs
+++ b/tests/test_batch_emitter.rs
@@ -1,10 +1,11 @@
+use std::sync::{atomic::AtomicUsize, Arc};
+
+use snowplow_tracker::{BatchEmitter, InMemoryEventStore, ScreenViewEvent, Tracker};
 use testcontainers::clients::Cli;
 use uuid::Uuid;
 
-use snowplow_tracker::{BatchEmitter, InMemoryEventStore, ScreenViewEvent, Tracker};
-
 mod common;
-use common::{micro_endpoint, setup, wait_for_events};
+use common::{micro_endpoint, setup, wait_for_events, FlakeyHttpClient};
 
 #[tokio::test]
 async fn send_batches() {
@@ -21,15 +22,20 @@ async fn send_batches() {
 
     let mut tracker = Tracker::new("ns", "app_id", emitter, None);
 
+    let mut events = Vec::new();
     for _ in 0..800 {
-        let screenview_event = ScreenViewEvent::builder()
-            .id(Uuid::new_v4())
-            .name("a screen view")
-            .previous_name("previous screen")
-            .build()
-            .unwrap();
+        events.push(
+            ScreenViewEvent::builder()
+                .id(Uuid::new_v4())
+                .name("a screen view")
+                .previous_name("previous screen")
+                .build()
+                .unwrap(),
+        );
+    }
 
-        tracker.track(screenview_event, None).unwrap();
+    for event in events {
+        tracker.track(event, None).unwrap();
     }
 
     wait_for_events(&micro_url, "good", 800).await;
@@ -73,4 +79,47 @@ async fn flush_emitter() {
     let all_events = micro_endpoint(&micro_url, "all").await;
 
     assert_eq!(350, all_events["good"]);
+}
+
+#[tokio::test]
+async fn successful_send_after_retry() {
+    let docker = Cli::default();
+    let (_container, micro_url) = setup(&docker);
+
+    let event_store = InMemoryEventStore::new(2, 1);
+
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    let http_client = FlakeyHttpClient {
+        micro_url: micro_url.clone(),
+        count: counter.clone(),
+        number_of_events_to_block: 2,
+    };
+
+    let emitter = BatchEmitter::builder()
+        .collector_url(&micro_url)
+        .event_store(event_store)
+        .http_client(http_client)
+        .build()
+        .unwrap();
+
+    let mut tracker = Tracker::new("ns", "app_id", emitter, None);
+
+    let screenview_event = ScreenViewEvent::builder()
+        .id(Uuid::new_v4())
+        .name("a screen view")
+        .previous_name("previous screen")
+        .build()
+        .unwrap();
+
+    tracker.track(screenview_event, None).unwrap();
+
+    wait_for_events(&micro_url, "good", 1).await;
+
+    tracker.close_emitter().unwrap();
+
+    let all_events = micro_endpoint(&micro_url, "all").await;
+
+    assert!(counter.load(std::sync::atomic::Ordering::SeqCst) == 2);
+    assert_eq!(1, all_events["good"]);
 }


### PR DESCRIPTION
This PR adds a retry mechanism to the `BatchEmitter`, along with a few other adjustments to make this possible.

# Crates

`rand` crate has been added for creating "jitter" in the retry delay.

# EventBatch

`id` and `delay` fields have been added. The event batch `id` is a `UUID`, taken from the first event in the vec of events in an `EventBatch` and is used to identify the batch in logging. The `delay` field is used to store the duration to delay sending by in retry.

- add `update_event_stm` and `update_batch_delay` methods to update the sent time for events in a batch and handle batch delay logic respectively.

# BatchEmitter

## Builder

The batch emitter builder now accepts a generic `HttpClient` implementation to the `http_client` field. This was done to be able to pass in the `FlakyHttpClient` in testing, but is equally useful for users to be able to create their own `HttpClient` implementations.

If no `HttpClient` is provided, `ReqwestClient` is used as a default.

## Retry

The retry mechanism for the batch emitter uses another tokio channel to attempt to re-send failed events batches. This channel (with it's components shown as `RetryReceiver` and `RetryTransmitter` in the diagram below) acts as both a store for retrying events and the method of retrying. It is an unbounded channel (e.g. the number of messages it can contain is not restricted), to match capacity of the "sending" HashMaps used in other trackers.

The overview of this method of retrying is that, instead of having to:

1. insert events into a `sending` dict when trying to send
2. get/remove the failed events from a `sending` dict
3. insert them into the event store
4. get them from the event store again

We make use of the existing `EventBatch` by assigning/updating its delay, and updating `stm` of each contained event before another send attempt. This has a nice benefit of not having to pass in and access the event store mutex from the tokio thread, removing any potential for mutex poisoning from the tokio loop thread.

The diagram below shows the potential paths an event will take based on if it has a delay, and/or fails to send.

```mermaid
flowchart TB  
    RetryReceiver-->|EventBatch|DelayCheck{Delay Check}
    EventReceiver-->|EventBatch|DelayCheck{Delay Check}

    DelayCheck{Batch has delay?}-->|true|DelayWait[wait delay period]
    DelayCheck{Batch has delay?}-->|false|SendBatch

    DelayWait-->UpdateSTM[[Batch.update_event_stm]]
    UpdateSTM-->SendBatch

    SendBatch{Send Batch}-->|Successful Send|log
    SendBatch{Send Batch}-->|Failed Send|UpdateDelay[[Batch.update_delay]]

    UpdateDelay-->|EventBatch|RetryTransmitter
    RetryTransmitter-->|EventBatch|RetryReceiver
```

An `EventBatch` delay is exponentially increased to a maximum of 10 minutes, with between 0-1s of jitter added onto a delay multiplier of 2, effectively giving us a delay increase of `prev_delay_time * random_number_between(2, 3)`.

## send_batch

The return type of `send_batch` has been changed from `Result<(), Error>` to `Result<Uuid, EventBatch>`

`send_batch` now returns the passed in `EventBatch` if the batch fails to send. This allows us not to have to perform a `clone` on the EventBatch for every batch (which may be rather large). The clone was required as, previously, the event batch was moved into `send_batch`.

The relevant debug log that was in the main tokio loop has been moved into the `send_batch` function body.

The batch id `Uuid` is returned on success for logging.

## Flush

Based on [Matus' Comment](https://github.com/snowplow/snowplow-rust-tracker/pull/25#discussion_r1035681644), flush now works by creating and sending `full_batch`s until there aren't enough to create a full batch, at which point a batch is created of any remaining events in the event store. I'm not sure his concern is an issue with this implementation of retry, but sending one huge batch of every event in the store wasn't a great solution regardless.

## Other minor BatchEmitter changes

- batch id has been included in logging where possible
- the debug log in `rx.recv()` has been removed, as the output of that log included the entire string of every event in the batch
- removed some redundant borrow/mut for `rx`
- removed un-needed cloning of `tx`
- adjust "waiting for task" debug log to start from 1, rather than 0

# Payload

- `stm` is now `pub (crate)` to allow us to access and modify when retrying

# Test

- add `FlakyHttpClient` to test retry, which can fail to send `n` times until sending successfully
- added a timeout to `wait_for_events` to prevent tests running infinitely in the case of events never being present
- updated `std::time::sleep` to `tokio::time::sleep` to allow any other async tasks to continue
