### PR TITLE
Remove hard-coded version number (close #32)

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -392,7 +392,7 @@ mod tests {
     fn payload_builder() -> PayloadBuilder {
         Payload::builder()
             .p("platform".to_string())
-            .tv("0.1.0".to_string())
+            .tv(format!("rust-{}", env!("CARGO_PKG_VERSION")))
             .eid(Uuid::new_v4())
             .dtm("1".to_string())
             .stm("1".to_string())

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -59,7 +59,7 @@ impl Tracker {
             subject: subject.unwrap_or(Subject::default()),
             config: TrackerConfig {
                 platform: "pc".to_string(),
-                version: "rust-0.1.0".to_string(),
+                version: format!("rust-{}", env!("CARGO_PKG_VERSION")),
                 encode_base_64: false,
             },
         }
@@ -201,7 +201,10 @@ mod tests {
         assert_eq!(tracker.emitter.collector_url(), "http://example.com/");
         assert_eq!(tracker.subject.user_id, Some("user_1".to_string()));
         assert_eq!(tracker.config.platform, "pc".to_string());
-        assert_eq!(tracker.config.version, "rust-0.1.0".to_string());
+        assert_eq!(
+            tracker.config.version,
+            format!("rust-{}", env!("CARGO_PKG_VERSION"))
+        );
         assert_eq!(tracker.config.encode_base_64, false);
 
         tracker.close_emitter().unwrap();


### PR DESCRIPTION
The `CARGO_PKG_VERSION` envvar provided by Cargo can be used to get the version number present in `Cargo.toml`